### PR TITLE
Feature/extract column data from df

### DIFF
--- a/spark_board/plan_extractor/dag.py
+++ b/spark_board/plan_extractor/dag.py
@@ -6,10 +6,7 @@ from .plan_parser import Node
 
 @dataclasses.dataclass
 class DFSNodeData:
-    # unique identifier of the node in the context of the DFS
-    node_id: int
-
-    # identifier of the parent node in the context of the DFS
+    # identifier of the parent node
     # Note that, for the root node only, the `parent_id` is None
     parent_id: Optional[int]
 
@@ -31,19 +28,16 @@ def dfs(root: Node) -> Generator[Tuple[DFSNodeData, Node], None, None]:
     """Returns a generator that iterates over the tree in depth-first order.
     Each element yielded by the generator is a tuple of (DFSNodeData, node)."""
 
-    # counter to assign a unique identifier to each node
-    next_node_id = 0
-    parents: Dict[int, Optional[int]] = {next_node_id: None}
-    nodes: Dict[int, Node] = {next_node_id: root}
-    stack: List[int] = [next_node_id]
-    depths: Dict[int, int] = {next_node_id: 0}
+    parents: Dict[int, Optional[int]] = {root.id: None}
+    nodes: Dict[int, Node] = {root.id: root}
+    stack: List[int] = [root.id]
+    depths: Dict[int, int] = {root.id: 0}
 
     while stack:
         node_id = stack.pop()
 
         # yield the node data and the node itself
         data = DFSNodeData(
-            node_id=node_id,
             parent_id=parents[node_id],
             parent=nodes[parents[node_id]] if parents[node_id] is not None else None,
             depth=depths[node_id],
@@ -53,12 +47,11 @@ def dfs(root: Node) -> Generator[Tuple[DFSNodeData, Node], None, None]:
         # push all children to the stack in order to iterate them later
         # we assume this is a tree, so no cycles should happen here
         for child in nodes[node_id].children:
-            next_node_id += 1
-            nodes[next_node_id] = child
-            parents[next_node_id] = node_id
-            depths[next_node_id] = depths[node_id] + 1
+            nodes[child.id] = child
+            parents[child.id] = node_id
+            depths[child.id] = depths[node_id] + 1
 
-            stack.append(next_node_id)
+            stack.append(child.id)
 
 
 # TODO: Check what needs to be parameterized, and eventually analyze if it should be

--- a/spark_board/plan_extractor/plan_parser.py
+++ b/spark_board/plan_extractor/plan_parser.py
@@ -22,6 +22,7 @@ class NodeColumn(object):
     name: str
     id: int
     type: str
+    node_id: int
 
     # List of the columns in previous nodes which form this column. This can be used
     # to navigate recursively until the data sources and discover its origins.
@@ -30,6 +31,7 @@ class NodeColumn(object):
 
 @dataclasses.dataclass
 class Node:
+    id: int
     type: NodeType
     metadata: Dict[str, str]  # TODO: make it more type specific
     children: List['Node']
@@ -106,6 +108,7 @@ class NodeParser(object):
         columns = self._parse_columns(java_node, children)
 
         return Node(
+            id=id(self),
             type=self._get_type(),
             metadata=metadata,
             children=children,
@@ -143,6 +146,7 @@ class NodeParser(object):
             name=column_name,
             id=column_id,
             type=data_type,
+            node_id=id(self),
             links=links
         )
 


### PR DESCRIPTION
Add column data in Python JSON dump to `model.js` file.

The column data will be used to build the column relations graph.
Include column sources from one transformation to another one, along with the ID of the transformation node that owns the column.