### PR TITLE
CI: fix deploy examples github action

### DIFF
--- a/.github/workflows/compile-ui.yml
+++ b/.github/workflows/compile-ui.yml
@@ -1,0 +1,48 @@
+# this is a reusable workflow to build the compiled spark-board React UI
+# it's not intended to run as a standalone workflow, but rather to be
+# called ("used") from other workflows
+
+on:
+  workflow_call:
+    inputs:
+      # the `artifact-name` defines the reference name for the generated
+      # artifacts (compiled UI static files) so other jobs can download them.secrets:
+      # the value can be used like ${{ needs.<name>.outputs.artifact-name }}
+      artifact-name:
+          required: true
+          type: string
+
+    outputs:
+      artifact-name:
+        description: |
+          Same input value `artifact-name` that can be used in other jobs.
+          This is a workaround to Github actions not being able to define constants, so
+          in this way the same input can be used in other parts of the workflow.
+        value: ${{ inputs.artifact-name }}
+
+jobs:
+  # this job will compile the UI and upload it as an artifact
+  # we need node js to do it, so we create a separate job for it
+  compile-ui:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20.2.0
+      - name: Build UI
+        run: |
+          cd spark-board-ui
+          npm install
+          npm run build
+          mv dist ../dist-spark-board-ui
+
+      # this stage will upload the compiled UI so the next ones can use it
+      - name: Upload spark-board-ui
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ./dist-spark-board-ui
+          if-no-files-found: error

--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -10,10 +10,16 @@ permissions:
   contents: read
   pages: write
   id-token: write
-      
+
 jobs:
+  compile-ui:
+    uses: ./.github/workflows/compile-ui.yml
+    with:
+      artifact-name: spark-board-ui
+
   Build:
     runs-on: ubuntu-22.04
+    needs: compile-ui
     strategy:
       max-parallel: 5
 
@@ -32,12 +38,19 @@ jobs:
         pip install pipenv==2023.4.29
         pipenv sync
 
+    # now collect the compiled UI from the previous job and insert it into the package
+    - name: Download compiled UI
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ needs.compile-ui.outputs.artifact-name }}
+        path: spark_board/ui  # copy to the package's ui folder
+
     - name: Build examples
       run: |
         pipenv run python ./scripts/build_examples.py --output ./examples
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v3
       with:
         name: page
         path: ./examples
@@ -52,7 +65,7 @@ jobs:
 
     steps:
     - name: Collect artifacts
-      uses: actions/download-artifact@master
+      uses: actions/download-artifact@v3
       with:
         name: page
         path: ./examples
@@ -67,4 +80,4 @@ jobs:
 
     - name: Deploy examples to pages
       id: deployment
-      uses: actions/deploy-pages@main
+      uses: actions/deploy-pages@v2

--- a/.github/workflows/deploy-spark-board-package.yml
+++ b/.github/workflows/deploy-spark-board-package.yml
@@ -9,30 +9,10 @@ on:
       - created
 
 jobs:
-  # this job will compile the UI and upload it as an artifact
-  # we need node js to do it, so we create a separate job for it
   compile-ui:
-    runs-on: ubuntu-22.04
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 20.2.0
-      - name: Build UI
-        run: |
-          cd spark-board-ui
-          npm install
-          npm run build
-          mv dist ../dist-spark-board-ui
-
-      # this stage will upload the compiled UI so the deploy stage can add it to the package
-      - name: Upload spark-board-ui
-        uses: actions/upload-artifact@master
-        with:
-          name: spark-board-ui
-          path: ./dist-spark-board-ui
+    uses: ./.github/workflows/compile-ui.yml
+    with:
+      artifact-name: spark-board-ui
 
   # build the Python package and upload it to pypi
   Deploy:
@@ -58,11 +38,11 @@ jobs:
           python3 -m pip install --upgrade build
 
       # now collect the compiled UI from the previous job and insert it into the package
-      - name: Download spark-board-ui
-        uses: actions/download-artifact@master
+      - name: Download compiled UI
+        uses: actions/download-artifact@v3
         with:
-          name: spark-board-ui
-          path: ./spark_board/ui  # copy to the package's ui folder
+          name: ${{ needs.compile-ui.outputs.artifact-name }}
+          path: spark_board/ui  # copy to the package's ui folder
 
       - name: Build dist
         run: python3 -m build


### PR DESCRIPTION
The step that builds the examples fails because the UI static files are not included in the source code anymore (see #37).

In order to fix it, we need to compile the UI before running the examples. To avoid repeating the steps, a new reusable workflow named `compile-ui.yml` is created that can be called from the other workflows.