### PR TITLE
Fix: relative links in package description in PyPI

### DIFF
--- a/.github/workflows/deploy-spark-board-package.yml
+++ b/.github/workflows/deploy-spark-board-package.yml
@@ -37,6 +37,12 @@ jobs:
           python3 -m pip install --upgrade twine
           python3 -m pip install --upgrade build
 
+      - name: Process README
+        run: |
+          # overwrite the README.md with the rendered version
+          REL_LINKS_BASE=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/tree/${GITHUB_REF_NAME}/
+          python3 ./scripts/readme_renderer.py --file ./README.md --rel-links-base "$REL_LINKS_BASE" --output ./README.md
+
       # now collect the compiled UI from the previous job and insert it into the package
       - name: Download compiled UI
         uses: actions/download-artifact@v3

--- a/scripts/readme_renderer.py
+++ b/scripts/readme_renderer.py
@@ -1,0 +1,56 @@
+"""
+We use the repository README as the package long description. This is done by reading the
+README file and applying some transformations to it.
+However, this is not so straightforward because the README file contains relative links,
+which Github transforms to the corresponding absolute links. But when PyPI renders the
+links, they are broken because they are relative to PyPI and not Github.
+"""
+
+import re
+from pathlib import Path
+from typing import Match
+
+
+# regular expression to match Markdown links
+MD_LINK_RE = re.compile(r"\[(.*?)\]\((?!https://)(.*?)\)")
+
+
+def process_readme(path: Path, base_url: str) -> str:
+    """Read the contents of the given README markdown file applyting the required
+    transformations and returns it.
+    `base_url` defines the base url to use prefix relative links."""
+    
+    data = path.read_text()    
+    return fix_links(data, base_url)
+
+
+def fix_links(data: str, base_url: str) -> str:
+    """Relative links work on the repository but will be broken in PyPI. This function will
+    convert them into absolute links."""
+
+    def replacer(match: Match[str]) -> str:
+        link = match.group(2)
+        if link.startswith("./"):
+            link = link[2:]
+
+        # recreate the link but with the base_url prepended
+        return f"[{match.group(1)}]({base_url + link})"
+
+    return MD_LINK_RE.sub(replacer, data)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rel-links-base", help="Base url to use for relative links", required=True)
+    parser.add_argument("--file", help="Path to the README file", required=True)
+    parser.add_argument("--output", help="Path to the output file", required=True)
+
+    args = parser.parse_args()
+
+    data = process_readme(
+        path=Path(args.file),
+        base_url=args.rel_links_base,
+    )
+    Path(args.output).write_text(data)

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,8 @@ README = (this_directory / "README.md").read_text()
 setup(
     name="spark-board",
     version="0.0.6",
-    authors=[
-        {"name": "Axel Lijdens", "email": "alijdens@fi.uba.ar"},
-        {"name": "Ezequiel Werner", "email": "ewerner@fi.uba.ar"},
-    ],
+    author="Axel Lijdens, Ezequiel Werner",
+    url="https://github.com/alijdens/spark-board",
     description="Interactive visualization of Spark jobs",
     long_description_content_type="text/markdown",
     long_description=README,

--- a/tests/scripts/test_readme.md
+++ b/tests/scripts/test_readme.md
@@ -1,0 +1,9 @@
+# Title
+
+This is a [relative Link](./path/to/file) but this is an [absolute link](https://example.com).
+Only the relative link will be converted.
+
+## [Relative Link in the title](my/file.png)
+
+Here we write some text and then we add a link to a [relative link](./path/to/file) and
+another to an [absolute link](https://google.com).

--- a/tests/scripts/test_readme_reader.py
+++ b/tests/scripts/test_readme_reader.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+from scripts import readme_renderer
+
+
+def test_fix_links_without_any_link() -> None:
+    readme_renderer.fix_links("some text", "http://base.url/") == "some text"
+
+
+def test_fix_links_does_not_modify_absolute_links() -> None:
+    readme_renderer.fix_links(
+        "some text [link](http://absolute.url)", "http://base.url/"
+    ) == "some text [link](http://absolute.url)"
+    
+    
+def test_fix_links_preprends_the_base_url_to_the_relative_links() -> None:
+    readme_renderer.fix_links(
+        "some text [link](./relative/link)", "http://base.url/"
+    ) == "some text [link](http://base.url/relative/link)"
+
+
+def test_with_readme_file() -> None:
+    file = Path(__file__).parent / "test_readme.md"
+
+    expected = """# Title
+
+This is a [relative Link](http://base.url/path/to/file) but this is an [absolute link](https://example.com).
+Only the relative link will be converted.
+
+## [Relative Link in the title](http://base.url/my/file.png)
+
+Here we write some text and then we add a link to a [relative link](http://base.url/path/to/file) and
+another to an [absolute link](https://google.com).
+"""
+
+    assert readme_renderer.process_readme(file, "http://base.url/") == expected

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,10 +1,9 @@
-import pytest
 from pyspark.sql.session import SparkSession
 from spark_board.html import dump_dataframe, DefaultSettings
 from pathlib import Path
 
 
-def test_spark_board(spark: SparkSession) -> None:
+def test_spark_board(spark: SparkSession, tmp_path: Path) -> None:
     """This test intends to be a very simple smoke test for the normal spark-board
     usage."""
 
@@ -12,7 +11,7 @@ def test_spark_board(spark: SparkSession) -> None:
     df = spark.createDataFrame([], schema="struct<a:double, b:double, c:double>")
     df = df.withColumn("sum", (df.a + df.b) / df.c)
 
-    OUT_DIR = Path("spark_board_output")
+    OUT_DIR = tmp_path/"spark_board_output"
 
     # dump it expecting no errors
     dump_dataframe(


### PR DESCRIPTION
We are using the `README.md` file as the long description in the package. PyPI uses this long description as the package main page. The problem is that relative links are not being rendered properly. This is because Github will modify relative links to point to the repository files, but PyPI cannot do that.

To work around this issue, we replace the README by another version that has absolute links to the files in Github (to the corresponding release tag) instead.