### PR TITLE
Highlight column tracking nodes path

### DIFF
--- a/spark-board-ui/src/sidebar.jsx
+++ b/spark-board-ui/src/sidebar.jsx
@@ -150,7 +150,7 @@ function SideBar({ width, node, nodesById, onSelectedColumnChange, selectedColum
  * Monospaced text with horizontal scrollbar.
  */
 function Mono({ children }) {
-    return <div class="monospaced">{ children }</div>
+    return <div className="monospaced">{ children }</div>
 }
 
 /**


### PR DESCRIPTION
When selecting a column to show its source, all nodes that are not part of it will become transparent so that the actual path is highlighted. The effect is applied with a smooth transition to make it more visually appealing.

[Screencast from 16-07-23 15:10:49.webm](https://github.com/alijdens/spark-board/assets/63980668/e539a13a-7349-4776-ab65-bc146dae03ce)
