### PR TITLE
Allow users to set a link to the data frame source code

### DIFF
--- a/.github/workflows/deploy-examples.yml
+++ b/.github/workflows/deploy-examples.yml
@@ -47,7 +47,8 @@ jobs:
 
     - name: Build examples
       run: |
-        pipenv run python ./scripts/build_examples.py --output ./examples
+        SOURCE_CODE_BASE="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
+        pipenv run python ./scripts/build_examples.py --output ./examples --source-code-base $SOURCE_CODE_BASE
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3

--- a/scripts/build_examples.py
+++ b/scripts/build_examples.py
@@ -18,6 +18,7 @@ from spark_board import html
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output", help="Name of the output directory", default="out")
+    parser.add_argument("--source-code-base", help="Used to set the link to the example source code", default=None)
 
     args = parser.parse_args()
 
@@ -32,11 +33,17 @@ if __name__ == "__main__":
         example_name = file.replace(".py", "")    
         example = __import__(f"tests.examples.{example_name}", fromlist=["df"])
 
+        if args.source_code_base is not None:
+            link = f"{args.source_code_base}/tests/examples/{example_name}.py"
+        else:
+            link = None
+
         html.dump_dataframe(
             df=example.df,
             output_dir=out_dir/example_name,
             overwrite=True,
             default_settings=html.DefaultSettings(),
+            source_code_link=link,
         )
 
         example_names.append(example_name)

--- a/spark-board-ui/model.js
+++ b/spark-board-ui/model.js
@@ -8,6 +8,10 @@
  */
 
 
+const model_staticSettings = {
+    "sourceCodeLink": null
+};
+
 const model_defaultSettings = {
     "animationEnabled": true,
     "animationEnabledOnDrag": true,

--- a/spark-board-ui/src/App.jsx
+++ b/spark-board-ui/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useCallback, useEffect } from 'react';
 import ReactFlow, { useNodesState, useEdgesState, MiniMap, Panel, useNodesInitialized, useReactFlow } from 'reactflow';
 
+import SourceCodeLink from './sourceCodeLink';
 import { shallow } from 'zustand/shallow';
 import TransformationNode, { getTransformationStyle, useTransformationNodeStore, useTransformationNodeDimensionsSync } from './transformation';
 import ColumnNode from './column';
@@ -235,6 +236,7 @@ export default function App() {
                 deleteKeyCode={null}
             >
                 <Panel position="top-right"><Settings settings={settings} setSetting={setSetting} /></Panel>
+                <Panel position="top-left"><SourceCodeLink link={model_staticSettings.sourceCodeLink} /></Panel>
                 <CustomControls organizeNodes={organizeNodes} />
                 <MiniMap zoomable pannable nodeColor={node => {
                     if (node.type == "transformation") {

--- a/spark-board-ui/src/sidebar.jsx
+++ b/spark-board-ui/src/sidebar.jsx
@@ -106,7 +106,7 @@ function SideBar({ width, node, nodesById, onSelectedColumnChange, selectedColum
     if (!node) {
         // if no node is selected, do not render the sidebar
         return <div className="sidebar__preferences" style={{width: width, minWidth: width}}>
-            <img src={ SparkBoardLogo } style={logoStyle} />
+            <a href="https://pypi.org/project/spark-board/" target="_blank"><img src={ SparkBoardLogo } style={logoStyle} /></a>
             <h3 style={{textAlign: "center"}}>Just select one node!</h3>
         </div>
     }

--- a/spark-board-ui/src/sourceCodeLink.jsx
+++ b/spark-board-ui/src/sourceCodeLink.jsx
@@ -1,0 +1,13 @@
+/**
+ * Very simple component that renders a link to the source code of the Spark
+ * data frame (if defined).
+ */
+export default function SourceCodeLink({ link }) {
+    if (!link) {
+        return <></>;
+    }
+
+    return (
+        <a href={link} target="_blank">Dataframe source code</a>
+    )
+}

--- a/spark_board/html.py
+++ b/spark_board/html.py
@@ -3,6 +3,8 @@ import shutil
 import json
 import dataclasses
 
+from spark_board.plan_extractor.errors import RTFMException
+
 from .import env
 from .default_settings import DefaultSettings as DefaultSettings  # explicit re-export for mypy
 from .plan_extractor import dag
@@ -69,7 +71,7 @@ def dump_dataframe(
     except FileNotFoundError:
         # this shouldn't happen in production (installing from PyPI) because the files are
         # included in the package, so it happened during development or we messed up with packaging
-        raise Exception(
+        raise RTFMException(
             "The static UI files were not found. If you are running spark-board from source, "
             "make sure you compile it and copy the files there.\nSee "
             "https://github.com/alijdens/spark-board/tree/main/spark-board-ui#test-with-spark-board "

--- a/spark_board/html.py
+++ b/spark_board/html.py
@@ -10,12 +10,14 @@ from .plan_extractor.dag_builder import build_dag
 from .plan_extractor.transformations_dag import JoinCondition, TransformationColumn, TransformationNode, TransformationType
 
 from pyspark.sql import DataFrame
-from typing import Dict, Any, List, Tuple
+from typing import Dict, Any, List, Tuple, Optional
 
 
 # string template to build the JS file containing the graph definition as nodes
 # and links objects required by the framework that will draw them
 MODEL_FILE_TEMPLATE = """
+const model_staticSettings = {static_settings};
+
 const model_defaultSettings = {settings};
 
 const model_initialNodes = {nodes};
@@ -30,12 +32,22 @@ class Encoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, o)    
 
 
-def dump_dataframe(df: DataFrame, output_dir: str, overwrite: bool, default_settings: DefaultSettings, simplify_dag: bool=True) -> None:
+def dump_dataframe(
+        df: DataFrame,
+        output_dir: str,
+        overwrite: bool,
+        default_settings: DefaultSettings,
+        simplify_dag: bool = True,
+        source_code_link: Optional[str] = None,
+    ) -> None:
     """Create a visual representation of the given `dag` in HTML. The HTML
     files will be saved in the `output_dir` directory. If `overwrite` is
     True, the output directory will be deleted if it already exists.
     If `simplify_dag` is True, a series of heuristics will be applied to
-    simplify the resulting DAG."""
+    simplify the resulting DAG.
+    `source_code_link` is the link to the source code of the DataFrame. This
+    can be a link to a repository, for example. It will appear in the
+    generated site so users can go directly to the code."""
 
     tree = build_dag(df=df, simplify_dag=simplify_dag, allow_unknown_transformations=env.allow_unknown_transformations())
     nodes, links = get_nodes_and_links(tree)
@@ -44,6 +56,7 @@ def dump_dataframe(df: DataFrame, output_dir: str, overwrite: bool, default_sett
         nodes=json.dumps(nodes, indent=4, cls=Encoder),
         links=json.dumps(links, indent=4),
         settings=json.dumps(dataclasses.asdict(default_settings), indent=4),
+        static_settings=json.dumps({"sourceCodeLink": source_code_link}, indent=4),
     )
 
     if overwrite and os.path.exists(output_dir):

--- a/spark_board/html.py
+++ b/spark_board/html.py
@@ -73,9 +73,8 @@ def dump_dataframe(
         # included in the package, so it happened during development or we messed up with packaging
         raise RTFMException(
             "The static UI files were not found. If you are running spark-board from source, "
-            "make sure you compile it and copy the files there.\nSee "
-            "https://github.com/alijdens/spark-board/tree/main/spark-board-ui#test-with-spark-board "
-            "for more information."
+            "make sure you compile it and copy the files there.",
+            link="https://github.com/alijdens/spark-board/tree/main/spark-board-ui#test-with-spark-board"
         )
 
     # create the output file with the model data

--- a/spark_board/plan_extractor/errors.py
+++ b/spark_board/plan_extractor/errors.py
@@ -1,2 +1,8 @@
 class RTFMException(Exception):
-    pass
+    def __init__(self, msg: str, link: str) -> None:
+        super().__init__(msg)
+        self.link = link
+        self.msg = msg
+
+    def __str__(self) -> str:
+        return f"\n{self.msg}\nSee {self.link} for more information."

--- a/spark_board/plan_extractor/errors.py
+++ b/spark_board/plan_extractor/errors.py
@@ -1,0 +1,2 @@
+class RTFMException(Exception):
+    pass


### PR DESCRIPTION
Add a new optional parameter to `dump_dataframe` called `source_code_link` which allows users to define a link intended to point to the repository where the source code that generates the data frame for the corresponding visualization is stored.

![image](https://github.com/alijdens/spark-board/assets/63980668/894e1b24-48c2-4d72-8f04-4f6c31118829)


Also add this link to the examples deployed in Github pages so that they point to the corresponding example Python source code file.

Added a link in the logo that redirects to the [spark-board PyPI](https://pypi.org/project/spark-board/) site.